### PR TITLE
Removed BOM output from RSS content

### DIFF
--- a/src/Snow/Extensions/RssResponse.cs
+++ b/src/Snow/Extensions/RssResponse.cs
@@ -4,9 +4,11 @@
     using System.Collections.Generic;
     using System.IO;
     using System.ServiceModel.Syndication;
+    using System.Text;
     using System.Xml;
     using Models;
     using Nancy;
+    using Nancy.IO;
 
     public class RssResponse : Response
     {
@@ -56,10 +58,15 @@
 
             return stream =>
             {
-                using (XmlWriter writer = XmlWriter.Create(stream))
+                var encoding =
+                    new UTF8Encoding(false);
+
+                var streamWrapper =
+                    new UnclosableStreamWrapper(stream);
+
+                using (var writer = new XmlTextWriter(streamWrapper, encoding))
                 {
                     formatter.WriteTo(writer);
-
                 }
             };
         }


### PR DESCRIPTION
`XmlWriter.Create` was creating an `XmlTextWriter` with an `UTF-8` encoding that included the Byte Order Marker (BOM) which was causing some issues with certain rss readers. This fix creates an encoding that excludes the BOM in the written XML. It wraps the stream in an `UnclosableStreamWrapper` that prevents it from being closed by the `XmlTextWriter` once it's disposed.
