### PR TITLE
Improved view error message output

### DIFF
--- a/src/Snow/Exceptions/FileProcessingException.cs
+++ b/src/Snow/Exceptions/FileProcessingException.cs
@@ -6,7 +6,6 @@
     {
         public FileProcessingException(string message) : base(message)
         {
-            
         }
     }
 }

--- a/src/Snow/Extensions/StatusCodeExtension.cs
+++ b/src/Snow/Extensions/StatusCodeExtension.cs
@@ -1,29 +1,27 @@
 ﻿namespace Snow.Extensions
 {
+    using System.Text.RegularExpressions;
     using Exceptions;
-    using Nancy;
     using Nancy.Testing;
 
     public static class StatusCodeExtension
     {
-        public static void ThrowIfNotSuccessful(this HttpStatusCode code)
-        {
-            if (code != HttpStatusCode.OK)
-            {
-                throw new FileProcessingException("Failed to generate some file...");
-            }
-        }
-
         public static void ThrowIfNotSuccessful(this BrowserResponse response, string fileName)
         {
-            var body = response.Body.AsString();
+            var body = 
+                response.Body.AsString();
 
-            //if (result.StatusCode != HttpStatusCode.OK)
-            //Crappy check because Nancy returns 200 on a compilation error :(
             if (body.Contains("<title>Razor Compilation Error</title>") &&
                 body.Contains("<p>We tried, we really did, but we just can't compile your view.</p>"))
             {
-                throw new FileProcessingException("Processing failed composing " + fileName);
+                var match =
+                    Regex.Match(body, "<pre id=\"errorContents\">(?<content>.*)&lt;!DOCTYPE html&gt;", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+                var message = (match.Success) ?
+                    match.Groups["content"].Value :
+                    string.Empty;
+
+                throw new FileProcessingException(message);
             }
         }
     }


### PR DESCRIPTION
Tried something here
- Captures the error from the razor error view
- Outputs it in a decent format
- Breaks on exception (no need to parse more files if one failed.. fix it and re-run Snow)
