### PR TITLE
Atom feed should use absolute URLs

### DIFF
--- a/src/Snow/Extensions/AtomResponse.cs
+++ b/src/Snow/Extensions/AtomResponse.cs
@@ -41,7 +41,7 @@
             {
                 // Replace all relative urls with full urls.
                 var contentHtml = Regex.Replace(post.Content, UrlRegex, m => siteUrl.TrimEnd('/') + "/" + m.Value.TrimStart('/'));
-                var excerptHtml = Regex.Replace(post.Content, UrlRegex, m => siteUrl.TrimEnd('/') + "/" + m.Value.TrimStart('/'));
+                var excerptHtml = Regex.Replace(post.ContentExcerpt, UrlRegex, m => siteUrl.TrimEnd('/') + "/" + m.Value.TrimStart('/'));
 
                 var item = new SyndicationItem(
                     post.Title,


### PR DESCRIPTION
For both the full content and the excerpt.
