### PR TITLE
Teach FolderCopy to understand the "." destination

### DIFF
--- a/src/Snow/Extensions/IoExtensions.cs
+++ b/src/Snow/Extensions/IoExtensions.cs
@@ -81,7 +81,7 @@
                 var temppath = Path.Combine(destDirName, file.Name);
 
                 // Copy the file.
-                file.CopyTo(temppath, false);
+                file.CopyTo(temppath, true);
             }
 
             // If copySubDirs is true, copy the subdirectories.

--- a/src/Snow/Program.cs
+++ b/src/Snow/Program.cs
@@ -138,7 +138,9 @@
                         }
                     }
 
-                    var destination = Path.Combine(settings.Output, destinationDir);
+                    // If the destination directory is "." copy the folder files to the output folder root
+                    var destination = destinationDir == "." ? settings.Output : Path.Combine(settings.Output, destinationDir);
+
                     new DirectoryInfo(source).Copy(destination, true);
                 }
 


### PR DESCRIPTION
Additionally, we should overwrite all files when we are performing a copy.
