### PR TITLE
Feature Inquiry - Pages accessable as /slug.html rather than /slug/

### DIFF
--- a/src/Snow/Extensions/SlugExtensions.cs
+++ b/src/Snow/Extensions/SlugExtensions.cs
@@ -58,7 +58,7 @@
         {
             foreach (var postHeader in posts)
             {
-                var urlFormat = "/" + settings.UrlFormat.Trim('/') + "/";
+                var urlFormat = "/" + settings.UrlFormat.Trim('/');
 
                 if (postHeader.Published == Published.Draft)
                 {

--- a/src/Snow/Program.cs
+++ b/src/Snow/Program.cs
@@ -266,12 +266,12 @@
 
                 var outputFolder = Path.Combine(output, post.Url.Trim('/')); //Outputfolder is incorrect with leading slash on urlFormat
 
-                if (!Directory.Exists(outputFolder))
+                if (!Directory.Exists(Path.GetDirectoryName(outputFolder)))
                 {
-                    Directory.CreateDirectory(outputFolder);
+                    Directory.CreateDirectory(Path.GetDirectoryName(outputFolder));
                 }
 
-                File.WriteAllText(Path.Combine(outputFolder, "index.html"), body);
+                File.WriteAllText(outputFolder, body);
             }
             catch (Exception)
             {

--- a/src/Snow/StaticFileProcessors/StaticFileProcessor.cs
+++ b/src/Snow/StaticFileProcessors/StaticFileProcessor.cs
@@ -10,10 +10,10 @@
         {
             get { return ""; }
         }
-        
+
         protected override void Impl(SnowyData snowyData, SnowSettings settings)
         {
-            TestModule.GeneratedUrl = settings.SiteUrl + "/" + DestinationName.Trim(new[] {'/'}) + "/";
+            TestModule.GeneratedUrl = settings.SiteUrl + "/" + DestinationName.Trim(new[] { '/' }) + "/";
 
             var result = snowyData.Browser.Post("/static");
 


### PR DESCRIPTION
**Not for merge**

This is a hack to build pages as `/slug.html` rather than `/slug/index.html`. I needed it to preserve my Blogger URLs.

Meant to work with `"urlFormat": "yyyy/MM/slug.html"`

Is there any interest in seeing this developed into an actual feature?
