### PR TITLE
Post ordering by exact date

### DIFF
--- a/src/Snow/PostParser.cs
+++ b/src/Snow/PostParser.cs
@@ -52,6 +52,19 @@
             var slug = fileNameMatches.Groups["slug"].Value.ToUrlSlug();
             var date = DateTime.ParseExact(year + month + day, "yyyyMMdd", CultureInfo.InvariantCulture);
 
+            /// if a 'date' property is found in markdown file header, that date will be used instead of the date in the file name
+            if (settings.ContainsKey("date"))
+            {
+                try
+                {
+                    date = DateTime.Parse((string)settings["date"]);
+                }
+                finally
+                {
+                    /// do nothing, let the current 'date' be as is
+                }
+            }
+
             var bodySerialized = Markdown.Transform(result.Body);
             var excerptSerialized = Markdown.Transform(result.Excerpt ?? string.Empty);
 


### PR DESCRIPTION
By default, posts are ordered by `YYYY-MM-DD` in the file name. This works as is intended, except for when you want to have more than one posts for a specific day. Then posts aren't exactly ordered by publish time. 
To solve this, if we introduce a `date` property to the markdown header file, we can set this `date` as the exact date for the post, and this makes correct ordering of posts possible.

a possible markdown header file:

```

---
...
date: 2014-04-30 23:02:42
...

---
```

(This is my first PR ever :D)
