### PR TITLE
#117  fixed issue with creating file paths running on a *nix environment

### DIFF
--- a/src/Snow/Program.cs
+++ b/src/Snow/Program.cs
@@ -105,7 +105,7 @@
 
                 foreach (var copyDirectory in settings.CopyDirectories)
                 {
-                    var sourceDir = (settings.ThemesDir + "\\" + settings.Theme + "\\" + copyDirectory);
+                    var sourceDir = (settings.ThemesDir + Path.DirectorySeparatorChar + settings.Theme + Path.DirectorySeparatorChar + copyDirectory);
 
                     var destinationDir = copyDirectory;
 
@@ -138,7 +138,7 @@
 
                 foreach (var copyFile in settings.CopyFiles)
                 {
-                    var sourceFile = (settings.ThemesDir + "\\" + settings.Theme + "\\" + copyFile);
+                    var sourceFile = (settings.ThemesDir + Path.DirectorySeparatorChar + settings.Theme + Path.DirectorySeparatorChar + copyFile);
                     var source = Path.Combine(settings.CurrentDir, sourceFile);
                     var destinationFile = copyFile;
 


### PR DESCRIPTION
This uses the constant Path.DirectorySeperatorChar instead of "\" to support both forward slashes and backward slashes in directory paths.
