### PR TITLE
Allow posts to be stored in subdirectories

### DIFF
--- a/src/Snow/Program.cs
+++ b/src/Snow/Program.cs
@@ -54,7 +54,7 @@
                 var settings = CreateSettings(currentDir);
 
                 var extensions = new HashSet<string>(new[] { ".md", ".markdown" }, StringComparer.OrdinalIgnoreCase);
-                var files = new DirectoryInfo(settings.Posts).EnumerateFiles()
+                var files = new DirectoryInfo(settings.Posts).EnumerateFiles("*", SearchOption.AllDirectories)
                                                              .Where(x => extensions.Contains(x.Extension));
 
                 SetupOutput(settings);


### PR DESCRIPTION
If you have a lot of posts, then having all of them stored in one folder can be a little untidy. I also do a lot of my writing/editing using gvim, and having a massive list of post files to scroll through with NERDTree is a pain, and, it can be awkward at times from the command line when renaming/moving drafts.

Also, it just sets my OCD off :bomb: 

`EnumerateFiles` has an overload which allows a search pattern and search options. Swapped it to use this with the default search pattern of '*' and the `SearchOption.AllDirectories`, which searches the current directory and it's subdirectories.

The great thing with this is, if you have no subdirectories, it doesn't matter, and all your posts still get picked up as normal.
