### PR TITLE
Make feed size configurable

### DIFF
--- a/src/Snow/SnowSettings.cs
+++ b/src/Snow/SnowSettings.cs
@@ -73,6 +73,8 @@
 
         public int PageSize { get; set; }
 
+        public int FeedSize { get; set; }
+
         public static SnowSettings Default(string directory)
         {
             return new SnowSettings
@@ -87,6 +89,7 @@
                 CopyFiles = new string[] {},
                 ProcessFiles = new List<StaticFile>(),
                 PageSize = 10,
+                FeedSize = 25,
                 Author = string.Empty,
                 Email = string.Empty,
                 DefaultPostLayout = "post"

--- a/src/Snow/TestModule.cs
+++ b/src/Snow/TestModule.cs
@@ -106,9 +106,9 @@
                 return View[result.Layout, result];
             };
 
-            Post["/rss"] = x => Response.AsRSS(Posts, Settings.BlogTitle, Settings.SiteUrl, StaticFile);
+            Post["/rss"] = x => Response.AsRSS(Posts.Take(Settings.FeedSize), Settings.BlogTitle, Settings.SiteUrl, StaticFile);
 
-            Post["/atom"] = x => Response.AsAtom(Posts, Settings.BlogTitle, Settings.SiteUrl, Settings.Author, Settings.Email, StaticFile);
+            Post["/atom"] = x => Response.AsAtom(Posts.Take(Settings.FeedSize), Settings.BlogTitle, Settings.SiteUrl, Settings.Author, Settings.Email, StaticFile);
 
             Post["/sitemap"] = x =>
             {


### PR DESCRIPTION
With the change that made all posts included in the RSS/Atom feeds, this can result in feed.xml files which are unreasonably large. Allowing the number of posts included in the feed to be configurable is a good way of addressing this. Additionally, in many cases it's desirable for this feed size number to be different from the number of posts included in the website paging system.
