### PR TITLE
use snow base view model instead of dynamic as type param in layouts...

### DIFF
--- a/SnowSite/Snow/themes/snowbyte/_layouts/default.cshtml
+++ b/SnowSite/Snow/themes/snowbyte/_layouts/default.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits Nancy.ViewEngines.Razor.NancyRazorViewBase<dynamic>
+﻿@inherits Nancy.ViewEngines.Razor.NancyRazorViewBase<Snow.ViewModels.BaseViewModel>
 @using System.Collections.Generic
 @{
     var keywords = String.Join(",", Model.Keywords);

--- a/SnowSite/Snow/themes/snowbyte/_layouts/post.cshtml
+++ b/SnowSite/Snow/themes/snowbyte/_layouts/post.cshtml
@@ -1,4 +1,4 @@
-@inherits Nancy.ViewEngines.Razor.NancyRazorViewBase<dynamic>
+@inherits Nancy.ViewEngines.Razor.NancyRazorViewBase<Snow.ViewModels.BaseViewModel>
 @using System.Collections.Generic
 @{
   Layout = "default.cshtml";


### PR DESCRIPTION
This is to avoid type errors during site generation at the calls to `@Html.CanonicalUrl()`