### PR TITLE
Added compile.snow.ps1 to list of ignored files in cleanup

### DIFF
--- a/src/Snow/Extensions/IoExtensions.cs
+++ b/src/Snow/Extensions/IoExtensions.cs
@@ -12,7 +12,7 @@
             return names.Contains(name.ToLower(), StringComparer.OrdinalIgnoreCase);
         }
 
-        private static readonly string[] IgnoredFiles = { "cname", "compile.snow.bat", "snow.config", ".nojekyll", ".gitignore", ".deployment" };
+        private static readonly string[] IgnoredFiles = { "cname", "compile.snow.bat", "compile.snow.ps1", "snow.config", ".nojekyll", ".gitignore", ".deployment" };
         private static readonly string[] IgnoredDirectories = { ".git", "svn", ".svn", "snow", ".nojekyll", ".gitignore" };
 
         public static void Empty(this DirectoryInfo directory)


### PR DESCRIPTION
Just a simple addition of ignoring a single powershell script just like the bat, sorta tempted to spike a .snowignore file with the basics in it.